### PR TITLE
Fix anchor model for drawing rendering

### DIFF
--- a/lib/xlsx/xform/drawing/drawing-xform.js
+++ b/lib/xlsx/xform/drawing/drawing-xform.js
@@ -25,7 +25,7 @@ class DrawingXform extends BaseXform {
     model.anchors.forEach((item, index) => {
       item.anchorType = getAnchorType(item);
       const anchor = this.map[item.anchorType];
-      anchor.prepare(item, {index});
+      anchor.prepare(item, { index });
     });
   }
 
@@ -39,7 +39,36 @@ class DrawingXform extends BaseXform {
 
     model.anchors.forEach(item => {
       const anchor = this.map[item.anchorType];
-      anchor.render(xmlStream, item);
+
+      // 🛠 Patch: Ensure the structure matches what anchor xforms expect
+      const anchorModel = {
+        range: {
+          editAs: item.range?.editAs || 'oneCell',
+          tl: {
+            col: item.range?.tl?.col ?? 0,
+            row: item.range?.tl?.row ?? 0,
+            colOff: item.range?.tl?.colOff ?? 0,
+            rowOff: item.range?.tl?.rowOff ?? 0,
+          },
+          br: {
+            col: item.range?.br?.col ?? 0,
+            row: item.range?.br?.row ?? 0,
+            colOff: item.range?.br?.colOff ?? 0,
+            rowOff: item.range?.br?.rowOff ?? 0,
+          },
+        },
+        picture: {
+          imageId: item.picture?.imageId,
+          ext: {
+            cx: item.picture?.ext?.cx ?? 0,
+            cy: item.picture?.ext?.cy ?? 0,
+          },
+          hyperlink: item.picture?.hyperlink,
+          tooltip: item.picture?.tooltip,
+        },
+      };
+
+      anchor.render(xmlStream, anchorModel);
     });
 
     xmlStream.closeNode();


### PR DESCRIPTION
## Summary
- tweak anchor prepare call spacing
- ensure anchor data is structured correctly when rendering drawings

## Testing
- `npm test` *(fails: `grunt: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6844f99cbc80832da6bd5c9996f3b6c3